### PR TITLE
don't read beyond end of buffer for strlen(cache_name) > 31

### DIFF
--- a/Driver/enhanceio/eio_ttc.c
+++ b/Driver/enhanceio/eio_ttc.c
@@ -553,6 +553,7 @@ out:
 static void eio_cache_rec_fill(struct cache_c *dmc, cache_rec_short_t *rec)
 {
 	strncpy(rec->cr_name, dmc->cache_name, sizeof(rec->cr_name));
+	rec->cr_name[sizeof(rec->cr_name)-1] = '\0';
 	strncpy(rec->cr_src_devname, dmc->disk_devname,
 		sizeof(rec->cr_src_devname));
 	strncpy(rec->cr_ssd_devname, dmc->cache_devname,


### PR DESCRIPTION
- eio_ttc.c (eio_cache_rec_fill): Ensure that rec->cr_name is
  always NUL-terminated.  It would lack a trailing NUL whenever
  strlen(dmc->cache_name) > CACHE_NAME_LEN.  The length of the
  cache_name string may be up to DEV_PATHLEN-1 (127), while the
  shorter destination buffer has length CACHE_NAME_SZ, 32.
  Each subsequent use of that cr_name member requires that it be
  NUL-terminated, so any use would read beyond end of buffer.

Signed-off-by: Jim Meyering meyering@fb.com
