### PR TITLE
format hardening (fixes FTBTS with "-Werror=format-security")

### DIFF
--- a/Driver/enhanceio/eio_conf.c
+++ b/Driver/enhanceio/eio_conf.c
@@ -117,7 +117,7 @@ static inline int eio_mem_available(struct cache_c *dmc, size_t size)
 /* create a new thread and call the specified function */
 void *eio_create_thread(int (*func)(void *), void *context, char *name)
 {
-	return kthread_run(func, context, name);
+	return kthread_run(func, context, "%s", name);
 }
 
 /* wait for the given thread to exit */


### PR DESCRIPTION
Driver/enhanceio/eio_conf.c: In function ‘eio_create_thread’:
    Driver/enhanceio/eio_conf.c:120:19: error: format not a string literal and no format arguments [-Werror=format-security]
