### PR TITLE
Fix for "Partitioned cache device causes "attempt to access beyond end of device" and kernel panic" for EnhanceIO.

### DIFF
--- a/Driver/enhanceio/eio.h
+++ b/Driver/enhanceio/eio.h
@@ -750,8 +750,8 @@ struct cache_c {
 
 #define EIO_CACHE_IOSIZE                0
 
-#define EIO_ROUND_SECTOR(dmc, sector) (sector & (~(unsigned)(dmc->block_size - 1)))
-#define EIO_ROUND_SET_SECTOR(dmc, sector) (sector & (~(unsigned)((dmc->block_size * dmc->assoc) - 1)))
+#define EIO_ROUND_SECTOR(dmc, sector) (sector & (~(unsigned long)(dmc->block_size - 1)))
+#define EIO_ROUND_SET_SECTOR(dmc, sector) (sector & (~(unsigned long)((dmc->block_size * dmc->assoc) - 1)))
 
 /*
  * The bit definitions are exported to the user space and are in the very beginning of the file.


### PR DESCRIPTION
There is a logical error in EIO_ROUND_SECTOR macro calculation.
The mask value used to align sector number to 8 sector boundary, is of 32 bit.

Any value for "sector" greater that 32 bit is getting truncated to smaller value
causing wrong calculation in eio_new_job for "job_io_regions.cache.sector".

This lead to the following error. "attempt to access beyond size of device."
Fix is to convert this 32 bit mask to 64 bit mask.

I have tested the fix by running mkfs.ext4 and doing read/writes beyond 2TB sector
on cache.

Signed off by abhansali@stec-inc.com
