### PR TITLE
Fix compilation errors with kernel 3.14

### DIFF
--- a/Driver/enhanceio/eio_main.c
+++ b/Driver/enhanceio/eio_main.c
@@ -93,7 +93,11 @@ static void bc_put(struct bio_container *bc, unsigned int doneio)
 	if (atomic_dec_and_test(&bc->bc_holdcount)) {
 		if (bc->bc_dmc->mode == CACHE_MODE_WB)
 			eio_release_io_resources(bc->bc_dmc, bc);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+		bc->bc_bio->bi_iter.bi_size = 0;
+#else 
 		bc->bc_bio->bi_size = 0;
+#endif 
 		dmc = bc->bc_dmc;
 
 		/* update iotime for latency */
@@ -2011,7 +2015,11 @@ static struct eio_bio *eio_new_ebio(struct cache_c *dmc, struct bio *bio,
 	int ios;
 
 	if (residual_biovec) {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+		int bvecindex = bio->bi_iter.bi_idx;
+#else 
 		int bvecindex = bio->bi_idx;
+#endif 
 		int rbvindex;
 
 		/* Calculate the number of bvecs required */
@@ -2042,6 +2050,16 @@ static struct eio_bio *eio_new_ebio(struct cache_c *dmc, struct bio *bio,
 		rbvindex = 0;
 		ios = iosize;
 		while (ios > 0) {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+			ebio->eb_rbv[rbvindex].bv_page =
+				bio->bi_io_vec[bio->bi_iter.bi_idx].bv_page;
+			ebio->eb_rbv[rbvindex].bv_offset =
+				bio->bi_io_vec[bio->bi_iter.bi_idx].bv_offset +
+				residual_biovec;
+			ebio->eb_rbv[rbvindex].bv_len =
+				bio->bi_io_vec[bio->bi_iter.bi_idx].bv_len -
+				residual_biovec;
+#else 
 			ebio->eb_rbv[rbvindex].bv_page =
 				bio->bi_io_vec[bio->bi_idx].bv_page;
 			ebio->eb_rbv[rbvindex].bv_offset =
@@ -2050,12 +2068,17 @@ static struct eio_bio *eio_new_ebio(struct cache_c *dmc, struct bio *bio,
 			ebio->eb_rbv[rbvindex].bv_len =
 				bio->bi_io_vec[bio->bi_idx].bv_len -
 				residual_biovec;
+#endif 
 			if (ebio->eb_rbv[rbvindex].bv_len > (unsigned)ios) {
 				residual_biovec += ios;
 				ebio->eb_rbv[rbvindex].bv_len = ios;
 			} else {
 				residual_biovec = 0;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+				bio->bi_iter.bi_idx++;
+#else 
 				bio->bi_idx++;
+#endif 
 			}
 			ios -= ebio->eb_rbv[rbvindex].bv_len;
 			rbvindex++;
@@ -2067,16 +2090,29 @@ static struct eio_bio *eio_new_ebio(struct cache_c *dmc, struct bio *bio,
 
 		if (!ebio)
 			return ERR_PTR(-ENOMEM);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+		ebio->eb_bv = bio->bi_io_vec + bio->bi_iter.bi_idx;
+#else 
 		ebio->eb_bv = bio->bi_io_vec + bio->bi_idx;
+#endif 
 		ios = iosize;
 		while (ios > 0) {
 			numbvecs++;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+			if ((unsigned)ios < bio->bi_io_vec[bio->bi_iter.bi_idx].bv_len) {
+#else 
 			if ((unsigned)ios < bio->bi_io_vec[bio->bi_idx].bv_len) {
+#endif 
 				residual_biovec = ios;
 				ios = 0;
 			} else {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+				ios -= bio->bi_io_vec[bio->bi_iter.bi_idx].bv_len;
+				bio->bi_iter.bi_idx++;
+#else 
 				ios -= bio->bi_io_vec[bio->bi_idx].bv_len;
 				bio->bi_idx++;
+#endif 
 			}
 		}
 	}
@@ -2112,11 +2148,19 @@ eio_disk_io(struct cache_c *dmc, struct bio *bio,
 	int residual_biovec = 0;
 	int error = 0;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+	/*disk io happens on whole bio. Reset bi_iter.bi_idx*/
+	bio->bi_iter.bi_idx = 0;
+	ebio =
+		eio_new_ebio(dmc, bio, &residual_biovec, bio->bi_iter.bi_sector,
+				 bio->bi_iter.bi_size, bc, EB_MAIN_IO);
+#else 
 	/*disk io happens on whole bio. Reset bi_idx*/
 	bio->bi_idx = 0;
 	ebio =
 		eio_new_ebio(dmc, bio, &residual_biovec, bio->bi_sector,
 			     bio->bi_size, bc, EB_MAIN_IO);
+#endif 
 
 	if (unlikely(IS_ERR(ebio))) {
 		bc->bc_error = error = PTR_ERR(ebio);
@@ -2136,11 +2180,19 @@ eio_disk_io(struct cache_c *dmc, struct bio *bio,
 	atomic_inc(&dmc->nr_jobs);
 	if (ebio->eb_dir == READ) {
 		job->action = READDISK;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+		SECTOR_STATS(dmc->eio_stats.disk_reads, bio->bi_iter.bi_size);
+#else 
 		SECTOR_STATS(dmc->eio_stats.disk_reads, bio->bi_size);
+#endif 
 		atomic64_inc(&dmc->eio_stats.readdisk);
 	} else {
 		job->action = WRITEDISK;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+		SECTOR_STATS(dmc->eio_stats.disk_writes, bio->bi_iter.bi_size);
+#else 
 		SECTOR_STATS(dmc->eio_stats.disk_writes, bio->bi_size);
+#endif 
 		atomic64_inc(&dmc->eio_stats.writedisk);
 	}
 
@@ -2162,7 +2214,11 @@ eio_disk_io(struct cache_c *dmc, struct bio *bio,
 	return;
 
 errout:
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+	eio_inval_range(dmc, bio->bi_iter.bi_sector, bio->bi_iter.bi_size);
+#else 
 	eio_inval_range(dmc, bio->bi_sector, bio->bi_size);
+#endif 
 	eio_flag_abios(dmc, anchored_bios, error);
 
 	if (ebio)
@@ -2264,9 +2320,15 @@ static int eio_acquire_set_locks(struct cache_c *dmc, struct bio_container *bc)
 	 * - acquire read lock on the set.
 	 */
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+	round_sector = EIO_ROUND_SET_SECTOR(dmc, bio->bi_iter.bi_sector);
+	set_size = dmc->block_size * dmc->assoc;
+	end_sector = bio->bi_iter.bi_sector + eio_to_sector(bio->bi_iter.bi_size);
+#else 
 	round_sector = EIO_ROUND_SET_SECTOR(dmc, bio->bi_sector);
 	set_size = dmc->block_size * dmc->assoc;
 	end_sector = bio->bi_sector + eio_to_sector(bio->bi_size);
+#endif 
 	first_set = -1;
 	last_set = -1;
 	cur_set = -1;
@@ -2456,7 +2518,11 @@ eio_release_io_resources(struct cache_c *dmc, struct bio_container *bc)
  */
 int eio_map(struct cache_c *dmc, struct request_queue *rq, struct bio *bio)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+	sector_t sectors = eio_to_sector(bio->bi_iter.bi_size);
+#else 
 	sector_t sectors = eio_to_sector(bio->bi_size);
+#endif 
 	struct eio_bio *ebio = NULL;
 	struct bio_container *bc;
 	sector_t snum;
@@ -2472,15 +2538,26 @@ int eio_map(struct cache_c *dmc, struct request_queue *rq, struct bio *bio)
 	struct eio_bio *eend = NULL;
 	struct eio_bio *enext = NULL;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+	EIO_ASSERT(bio->bi_iter.bi_idx == 0);
+#else 
 	EIO_ASSERT(bio->bi_idx == 0);
+#endif 
 
 	pr_debug("this needs to be removed immediately\n");
 
 	if (bio_rw_flagged(bio, REQ_DISCARD)) {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+		pr_debug
+			("eio_map: Discard IO received. Invalidate incore start=%lu totalsectors=%d.\n",
+			(unsigned long)bio->bi_iter.bi_sector,
+			(int)eio_to_sector(bio->bi_iter.bi_size));
+#else 
 		pr_debug
 			("eio_map: Discard IO received. Invalidate incore start=%lu totalsectors=%d.\n",
 			(unsigned long)bio->bi_sector,
 			(int)eio_to_sector(bio->bi_size));
+#endif 
 		bio_endio(bio, 0);
 		pr_err
 			("eio_map: I/O with Discard flag received. Discard flag is not supported.\n");
@@ -2500,10 +2577,18 @@ int eio_map(struct cache_c *dmc, struct request_queue *rq, struct bio *bio)
 		atomic64_inc(&dmc->size_hist[sectors]);
 
 	if (data_dir == READ) {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+		SECTOR_STATS(dmc->eio_stats.reads, bio->bi_iter.bi_size);
+#else 
 		SECTOR_STATS(dmc->eio_stats.reads, bio->bi_size);
+#endif 
 		atomic64_inc(&dmc->eio_stats.readcount);
 	} else {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+		SECTOR_STATS(dmc->eio_stats.writes, bio->bi_iter.bi_size);
+#else 
 		SECTOR_STATS(dmc->eio_stats.writes, bio->bi_size);
+#endif 
 		atomic64_inc(&dmc->eio_stats.writecount);
 	}
 
@@ -2531,7 +2616,11 @@ int eio_map(struct cache_c *dmc, struct request_queue *rq, struct bio *bio)
 	 * Process zero sized bios by passing original bio flags
 	 * to both HDD and SSD.
 	 */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+	if (bio->bi_iter.bi_size == 0) {
+#else 
 	if (bio->bi_size == 0) {
+#endif 
 		eio_process_zero_size_bio(dmc, bio);
 		return DM_MAPIO_SUBMITTED;
 	}
@@ -2550,9 +2639,15 @@ int eio_map(struct cache_c *dmc, struct request_queue *rq, struct bio *bio)
 	atomic_set(&bc->bc_holdcount, 1);
 	bc->bc_error = 0;
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
+	snum = bio->bi_iter.bi_sector;
+	totalio = bio->bi_iter.bi_size;
+	biosize = bio->bi_iter.bi_size;
+#else 
 	snum = bio->bi_sector;
 	totalio = bio->bi_size;
 	biosize = bio->bi_size;
+#endif 
 	residual_biovec = 0;
 
 	if (dmc->mode == CACHE_MODE_WB) {


### PR DESCRIPTION
In 3.14, bi_sector and bi_size were moved into an iterator.
