### PR TITLE
Enable write-only writeback cache via procfs.

### DIFF
--- a/CLI/eio_cli
+++ b/CLI/eio_cli
@@ -572,6 +572,11 @@ def create_parser():
 			          required=True, help="name of the ssd device")
 	parser_sanity.add_argument("-d", action="store", dest="hdd",\
 				  required=True, help="name of the source device")
+
+	#disable
+	parser_disable = parser.add_parser('disable', help='used to disable cache')
+	parser_disable.add_argument("-c", action="store", dest="cache", required=True)
+
 	return mainparser
 
 def main():
@@ -629,6 +634,10 @@ def main():
 				mode = args.mode, blksize = args.blksize, persistence = 1)
 
 		cache.do_eio_ioctl(EIO_IOC_ENABLE)
+
+	elif sys.argv[1] == "disable":
+		cache = Cache_rec(name = args.cache)
+		cache.do_eio_ioctl(EIO_IOC_DISABLE)
 
 	elif sys.argv[1] == "notify":
 		# This command will be fired by udev rule on SSD/Source addition

--- a/CLI/eio_cli
+++ b/CLI/eio_cli
@@ -645,7 +645,7 @@ def main():
 			elif args.hdd:
 				cache = Cache_rec(name = args.cache,\
 						ssd_name = args.hdd, persistence = 1)
-				cache.do_eio_ioctl(EIO_IOC_HDD_ADD)
+				cache.do_eio_ioctl(EIO_IOC_SRC_ADD)
 
 		elif args.action == "remove":
 			if args.ssd:
@@ -655,7 +655,7 @@ def main():
 			elif args.hdd:
 				cache = Cache_rec(name = args.cache, hdd_name = args.hdd,\
 						persistence = 1)
-				cache.do_eio_ioctl(EIO_HDD_REMOVE)
+				cache.do_eio_ioctl(EIO_SRC_REMOVE)
 
 		pass
 

--- a/Driver/enhanceio/eio.h
+++ b/Driver/enhanceio/eio.h
@@ -265,6 +265,7 @@ union eio_superblock {
 		__le32 dirty_low_threshold;
 		__le32 dirty_set_high_threshold;
 		__le32 dirty_set_low_threshold;
+		__le32 cache_wronly;
 		__le32 time_based_clean_interval;
 		__le32 autoclean_threshold;
 	} sbf;
@@ -666,6 +667,7 @@ struct eio_sysctl {
 	int32_t autoclean_threshold;
 	int32_t mem_limit_pct;
 	int32_t control;
+	int32_t cache_wronly;
 	u_int64_t invalidate;
 };
 

--- a/Driver/enhanceio/eio.h
+++ b/Driver/enhanceio/eio.h
@@ -43,6 +43,7 @@
 #include <linux/hash.h>
 #include <linux/spinlock.h>
 #include <linux/workqueue.h>
+#include <linux/completion.h>
 #include <linux/pagemap.h>
 #include <linux/random.h>
 #include <linux/hardirq.h>
@@ -576,13 +577,16 @@ struct mdupdate_request {
 
 #define SETFLAG_CLEAN_INPROG    0x00000001      /* clean in progress on a set */
 #define SETFLAG_CLEAN_WHOLE     0x00000002      /* clean the set fully */
+#define SETFLAG_CLEAN_ACTIVE    0x00000004      /* cache set is being cleaned up */
 
 /* Structure used for doing operations and storing cache set level info */
 struct cache_set {
 	struct list_head list;
 	u_int32_t nr_dirty;             /* number of dirty blocks */
 	spinlock_t cs_lock;             /* spin lock to protect struct fields */
-	struct rw_semaphore rw_lock;    /* reader-writer lock used for clean */
+	atomic_t pending;               /* pending I/Os on cache set */
+	struct completion clean_done;   /* Clean operation on set has been completed */
+	struct completion io_done;      /* all IO operations on set have been completed */
 	unsigned int flags;             /* misc cache set specific flags */
 	struct mdupdate_request *mdreq; /* metadata update request pointer */
 };
@@ -890,7 +894,8 @@ struct bio_container {
 
 /* structure used as callback context during synchronous I/O */
 struct sync_io_context {
-	struct rw_semaphore sio_lock;
+	atomic_t pending;
+	struct completion done;
 	unsigned long sio_error;
 };
 

--- a/Driver/enhanceio/eio.h
+++ b/Driver/enhanceio/eio.h
@@ -839,7 +839,7 @@ struct job_io_regions {
 #define GET_BIO_FLAGS(ebio)             ((ebio)->eb_bc->bc_bio->bi_rw)
 #define VERIFY_BIO_FLAGS(ebio)          EIO_ASSERT((ebio) && (ebio)->eb_bc && (ebio)->eb_bc->bc_bio)
 
-#if (RHEL_MAJOR == 6)
+#if defined(RHEL_MAJOR) && (RHEL_MAJOR == 6)
 #define SET_BARRIER_FLAGS(rw_flags) (rw_flags |= (REQ_WRITE | BIO_FLUSH))
 #else
 #define SET_BARRIER_FLAGS(rw_flags) (rw_flags |= (REQ_WRITE | REQ_FLUSH))

--- a/Driver/enhanceio/eio_conf.c
+++ b/Driver/enhanceio/eio_conf.c
@@ -315,6 +315,7 @@ int eio_sb_store(struct cache_c *dmc)
 	sb->sbf.time_based_clean_interval =
 		cpu_to_le32(dmc->sysctl_active.time_based_clean_interval);
 	sb->sbf.autoclean_threshold = cpu_to_le32(dmc->sysctl_active.autoclean_threshold);
+	sb->sbf.cache_wronly = cpu_to_le32(dmc->sysctl_active.cache_wronly);
 
 	/* write out to ssd */
 	where.bdev = dmc->cache_dev->bdev;
@@ -1142,6 +1143,7 @@ static int eio_md_load(struct cache_c *dmc)
 		le32_to_cpu(header->sbf.dirty_set_high_threshold);
 	dmc->sysctl_active.dirty_set_low_threshold =
 		le32_to_cpu(header->sbf.dirty_set_low_threshold);
+	dmc->sysctl_active.cache_wronly = le32_to_cpu(header->sbf.cache_wronly);
 	dmc->sysctl_active.time_based_clean_interval =
 		le32_to_cpu(header->sbf.time_based_clean_interval);
 	dmc->sysctl_active.autoclean_threshold =

--- a/Driver/enhanceio/eio_conf.c
+++ b/Driver/enhanceio/eio_conf.c
@@ -1594,6 +1594,7 @@ int eio_cache_create(struct cache_rec_short *cache)
 		}
 	}
 
+	spin_lock_init(&dmc->cache_spin_lock);
 	/*
 	 * We need to determine the requested cache mode before we call
 	 * eio_md_load becuase it examines dmc->mode. The cache mode is
@@ -1774,7 +1775,6 @@ int eio_cache_create(struct cache_rec_short *cache)
 	dmc->sysctl_active.time_based_clean_interval =
 		TIME_BASED_CLEAN_INTERVAL_DEF(dmc);
 
-	spin_lock_init(&dmc->cache_spin_lock);
 	if (persistence == CACHE_CREATE) {
 		error = eio_md_create(dmc, /* force */ 0, /* cold */ 1);
 		if (error) {
@@ -2569,6 +2569,7 @@ static int __init eio_init(void)
 	}
 	atomic_set(&nr_cache_jobs, 0);
 	INIT_WORK(&_kcached_wq, eio_do_work);
+	spin_lock_init(&ssd_rm_list_lock);
 
 	eio_module_procfs_init();
 	eio_control = kmalloc(sizeof(*eio_control), GFP_KERNEL);

--- a/Driver/enhanceio/eio_conf.c
+++ b/Driver/enhanceio/eio_conf.c
@@ -1812,7 +1812,9 @@ init:
 	for (i = 0; i < (dmc->size >> dmc->consecutive_shift); i++) {
 		dmc->cache_sets[i].nr_dirty = 0;
 		spin_lock_init(&dmc->cache_sets[i].cs_lock);
-		init_rwsem(&dmc->cache_sets[i].rw_lock);
+		atomic_set(&dmc->cache_sets[i].pending, 0);
+		init_completion(&dmc->cache_sets[i].clean_done);
+		init_completion(&dmc->cache_sets[i].io_done);
 		dmc->cache_sets[i].mdreq = NULL;
 		dmc->cache_sets[i].flags = 0;
 	}

--- a/Driver/enhanceio/eio_main.c
+++ b/Driver/enhanceio/eio_main.c
@@ -2659,7 +2659,7 @@ int eio_map(struct cache_c *dmc, struct request_queue *rq, struct bio *bio)
 
 	/* Create a bio container */
 
-	bc = kzalloc(sizeof(struct bio_container), GFP_NOWAIT);
+	bc = kzalloc(sizeof(struct bio_container), GFP_NOWAIT | GFP_NOIO);
 	if (!bc) {
 		bio_endio(bio, -ENOMEM);
 		return DM_MAPIO_SUBMITTED;

--- a/Driver/enhanceio/eio_main.c
+++ b/Driver/enhanceio/eio_main.c
@@ -2819,8 +2819,9 @@ static int eio_read_peek(struct cache_c *dmc, struct eio_bio *ebio)
 			goto out;
 		}
 
-		/* cache is marked readonly. Do not allow READFILL on SSD */
-		if (unlikely(dmc->cache_rdonly))
+		/* cache is marked readonly or set to wronly mode. */
+		/* Do not allow READFILL on SSD */
+		if (dmc->cache_rdonly || dmc->sysctl_active.cache_wronly)
 			goto out;
 
 		/*
@@ -2839,9 +2840,10 @@ static int eio_read_peek(struct cache_c *dmc, struct eio_bio *ebio)
 		goto out;
 	}
 	EIO_ASSERT(res == INVALID);
-
-	/* cache is marked readonly. Do not allow READFILL on SSD */
-	if (unlikely(dmc->cache_rdonly))
+	
+	/* cache is marked readonly or set to wronly mode. */
+	/* Do not allow READFILL on SSD */
+	if (dmc->cache_rdonly || dmc->sysctl_active.cache_wronly)
 		goto out;
 	/*
 	 * Found an invalid block to be used.

--- a/Driver/enhanceio/eio_main.c
+++ b/Driver/enhanceio/eio_main.c
@@ -2564,7 +2564,11 @@ int eio_map(struct cache_c *dmc, struct request_queue *rq, struct bio *bio)
 
 	pr_debug("this needs to be removed immediately\n");
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39))
 	if (bio_rw_flagged(bio, REQ_DISCARD)) {
+#else
+	if (bio_rw_flagged(bio, BIO_DISCARD)) {
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0))
 		pr_debug
 			("eio_map: Discard IO received. Invalidate incore start=%lu totalsectors=%d.\n",

--- a/Driver/enhanceio/eio_procfs.c
+++ b/Driver/enhanceio/eio_procfs.c
@@ -1255,11 +1255,12 @@ void eio_procfs_ctr(struct cache_c *dmc)
 
 	s = eio_cons_procfs_cachename(dmc, "");
 	entry = proc_mkdir(s, NULL);
-	kfree(s);
 	if (entry == NULL) {
 		pr_err("Failed to create /proc/%s", s);
+		kfree(s);
 		return;
 	}
+	kfree(s);
 
 	s = eio_cons_procfs_cachename(dmc, PROC_STATS);
 	entry = proc_create_data(s, 0, NULL, &eio_stats_operations, dmc);

--- a/Driver/enhanceio/eio_procfs.c
+++ b/Driver/enhanceio/eio_procfs.c
@@ -595,7 +595,7 @@ eio_dirty_set_low_threshold_sysctl(struct ctl_table *table, int write,
 }
 
 static int
-eio_cache_wronly_sysctl(ctl_table *table, int write,
+eio_cache_wronly_sysctl(struct ctl_table *table, int write,
 				   void __user *buffer, size_t *length,
 				   loff_t *ppos)
 {

--- a/Driver/enhanceio/eio_procfs.c
+++ b/Driver/enhanceio/eio_procfs.c
@@ -1083,6 +1083,9 @@ static struct sysctl_table_dir {
 	}, .dev	= {
 	}, .dir	= {
 		{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= PROC_SYS_DIR_NAME,
 			.maxlen		= 0,
 			.mode		= S_IRUGO | S_IXUGO,
@@ -1090,6 +1093,9 @@ static struct sysctl_table_dir {
 		},
 	}, .root = {
 		{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_DEV,
+#endif
 			.procname	= PROC_SYS_ROOT_NAME,
 			.maxlen		= 0,
 			.mode		= 0555,
@@ -1109,16 +1115,25 @@ static struct sysctl_table_common {
 } sysctl_template_common = {
 	.vars = {
 		{               /* 1 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= "zero_stats",
 			.maxlen		= sizeof(int),
 			.mode		= 0644,
 			.proc_handler	= &eio_zerostats_sysctl,
 		}, {            /* 2 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= "mem_limit_pct",
 			.maxlen		= sizeof(int),
 			.mode		= 0644,
 			.proc_handler	= &eio_mem_limit_pct_sysctl,
 		}, {            /* 3 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= "control",
 			.maxlen		= sizeof(int),
 			.mode		= 0644,
@@ -1126,6 +1141,9 @@ static struct sysctl_table_common {
 		},
 	}, .dev	= {
 		{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= PROC_SYS_CACHE_NAME,
 			.maxlen		= 0,
 			.mode		= S_IRUGO | S_IXUGO,
@@ -1133,6 +1151,9 @@ static struct sysctl_table_common {
 		},
 	}, .dir	= {
 		{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= PROC_SYS_DIR_NAME,
 			.maxlen		= 0,
 			.mode		= S_IRUGO | S_IXUGO,
@@ -1140,6 +1161,9 @@ static struct sysctl_table_common {
 		},
 	}, .root = {
 		{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_DEV,
+#endif
 			.procname	= PROC_SYS_ROOT_NAME,
 			.maxlen		= 0,
 			.mode		= 0555,
@@ -1159,45 +1183,69 @@ static struct sysctl_table_writeback {
 } sysctl_template_writeback = {
 	.vars = {
 		{               /* 1 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= "do_clean",
 			.maxlen		= sizeof(int),
 			.mode		= 0644,
 			.proc_handler	= &eio_clean_sysctl,
 		}, {            /* 2 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= "time_based_clean_interval",
 			.maxlen		= sizeof(unsigned int),
 			.mode		= 0644,
 			.proc_handler	= &eio_time_based_clean_interval_sysctl,
 		}, {            /* 3 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= "autoclean_threshold",
 			.maxlen		= sizeof(int),
 			.mode		= 0644,
 			.proc_handler	= &eio_autoclean_threshold_sysctl,
 		}, {            /* 4 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= "dirty_high_threshold",
 			.maxlen		= sizeof(uint32_t),
 			.mode		= 0644,
 			.proc_handler	= &eio_dirty_high_threshold_sysctl,
 		}
 		, {             /* 5 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= "dirty_low_threshold",
 			.maxlen		= sizeof(uint32_t),
 			.mode		= 0644,
 			.proc_handler	= &eio_dirty_low_threshold_sysctl,
 		}
 		, {             /* 6 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= "dirty_set_high_threshold",
 			.maxlen		= sizeof(uint32_t),
 			.mode		= 0644,
 			.proc_handler	= &eio_dirty_set_high_threshold_sysctl,
 		}
 		, {             /* 7 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= "dirty_set_low_threshold",
 			.maxlen		= sizeof(uint32_t),
 			.mode		= 0644,
 			.proc_handler	= &eio_dirty_set_low_threshold_sysctl,
 		}
 		, {		/* 8 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= "cache_wronly",
 			.maxlen		= sizeof(uint32_t),
 			.mode		= 0644,
@@ -1207,6 +1255,9 @@ static struct sysctl_table_writeback {
 	}
 	, .dev = {
 		{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= PROC_SYS_CACHE_NAME,
 			.maxlen		= 0,
 			.mode		= S_IRUGO | S_IXUGO,
@@ -1216,6 +1267,9 @@ static struct sysctl_table_writeback {
 	}
 	, .dir = {
 		{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= PROC_SYS_DIR_NAME,
 			.maxlen		= 0,
 			.mode		= S_IRUGO | S_IXUGO,
@@ -1225,6 +1279,9 @@ static struct sysctl_table_writeback {
 	}
 	, .root	= {
 		{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_DEV,
+#endif
 			.procname	= PROC_SYS_ROOT_NAME,
 			.maxlen		= 0,
 			.mode		= 0555,
@@ -1245,6 +1302,9 @@ static struct sysctl_table_invalidate {
 } sysctl_template_invalidate = {
 	.vars = {
 		{	/* 1 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= "invalidate",
 			.maxlen		= sizeof(u_int64_t),
 			.mode		= 0644,
@@ -1254,6 +1314,9 @@ static struct sysctl_table_invalidate {
 	}
 	, .dev = {
 		{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= PROC_SYS_CACHE_NAME,
 			.maxlen		= 0,
 			.mode		= S_IRUGO | S_IXUGO,
@@ -1263,6 +1326,9 @@ static struct sysctl_table_invalidate {
 	}
 	, .dir = {
 		{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_UNNUMBERED,
+#endif
 			.procname	= PROC_SYS_DIR_NAME,
 			.maxlen		= 0,
 			.mode		= S_IRUGO | S_IXUGO,
@@ -1272,6 +1338,9 @@ static struct sysctl_table_invalidate {
 	}
 	, .root	= {
 		{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,33)
+			.ctl_name       = CTL_DEV,
+#endif
 			.procname	= PROC_SYS_ROOT_NAME,
 			.maxlen		= 0,
 			.mode		= 0555,

--- a/Driver/enhanceio/eio_ttc.c
+++ b/Driver/enhanceio/eio_ttc.c
@@ -1392,7 +1392,7 @@ int eio_alloc_wb_bvecs(struct bio_vec *bvec, int max, int blksize)
 
 			if ((i % 2) == 0) {
 				/* Allocate page only for even bio vector */
-				page = alloc_page(GFP_KERNEL | __GFP_ZERO);
+				page = alloc_page(GFP_NOIO | __GFP_ZERO);
 				if (unlikely(!page)) {
 					pr_err
 						("eio_alloc_wb_bvecs: System memory too low.\n");
@@ -1417,7 +1417,7 @@ int eio_alloc_wb_bvecs(struct bio_vec *bvec, int max, int blksize)
 
 		case BLKSIZE_4K:
 		case BLKSIZE_8K:
-			page = alloc_page(GFP_KERNEL | __GFP_ZERO);
+			page = alloc_page(GFP_NOIO | __GFP_ZERO);
 			if (unlikely(!page)) {
 				pr_err("eio_alloc_wb_bvecs:" \
 				       " System memory too low.\n");

--- a/Driver/enhanceio/eio_ttc.c
+++ b/Driver/enhanceio/eio_ttc.c
@@ -489,7 +489,11 @@ re_lookup:
 	if (unlikely(overlap)) {
 		up_read(&eio_ttc_lock[index]);
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,39))
 		if (bio_rw_flagged(bio, REQ_DISCARD)) {
+#else
+		if (bio_rw_flagged(bio, BIO_DISCARD)) {
+#endif
 			pr_err
 				("eio_mfn: Overlap I/O with Discard flag." \
 				" Discard flag is not supported.\n");

--- a/Driver/enhanceio/eio_ttc.h
+++ b/Driver/enhanceio/eio_ttc.h
@@ -24,10 +24,12 @@
 #include <stdint.h>
 #endif                          /* __KERNEL__ */
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,1,0))
 static inline bool bio_rw_flagged(struct bio *bio, int flag)
 {
 	return (bio->bi_rw & flag) != 0;
 }
+#endif
 
 /*
  * Whether the cached (source) device is a partition or a whole device.


### PR DESCRIPTION
For some workloads it is very desirable to have write-only writeback
cache, when reads from cached device are not stored in SSD and writes
are buffered in SSD. Reads of already buffered data are carried out from SSD.
