### PR TITLE
fix compilation on kernel 3.17

### DIFF
--- a/Driver/enhanceio/eio.h
+++ b/Driver/enhanceio/eio.h
@@ -128,7 +128,11 @@ struct eio_control_s {
 	unsigned long synch_flags;
 };
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0))
+int eio_wait_schedule(struct wait_bit_key *unused);
+#else
 int eio_wait_schedule(void *unused);
+#endif
 
 struct eio_event {
 	struct task_struct *process;    /* handle of the sleeping process */

--- a/Driver/enhanceio/eio_conf.c
+++ b/Driver/enhanceio/eio_conf.c
@@ -89,7 +89,12 @@ static struct notifier_block eio_ssd_rm_notifier = {
 	.priority	= 0,
 };
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0))
+int eio_wait_schedule(struct wait_bit_key *unused)
+#else
+#define wait_on_bit_lock_action wait_on_bit_lock
 int eio_wait_schedule(void *unused)
+#endif
 {
 
 	schedule();
@@ -1842,7 +1847,7 @@ init:
 
 	dmc->sysctl_active.mem_limit_pct = 75;
 
-	(void)wait_on_bit_lock((void *)&eio_control->synch_flags,
+	(void)wait_on_bit_lock_action((void *)&eio_control->synch_flags,
 			       EIO_UPDATE_LIST, eio_wait_schedule,
 			       TASK_UNINTERRUPTIBLE);
 	dmc->next_cache = cache_list_head;
@@ -1901,7 +1906,7 @@ bad6:
 	vfree((void *)dmc->cache_sets);
 	vfree((void *)EIO_CACHE(dmc));
 
-	(void)wait_on_bit_lock((void *)&eio_control->synch_flags,
+	(void)wait_on_bit_lock_action((void *)&eio_control->synch_flags,
 			       EIO_UPDATE_LIST, eio_wait_schedule,
 			       TASK_UNINTERRUPTIBLE);
 	nodepp = &cache_list_head;
@@ -2055,7 +2060,7 @@ force_delete:
 	vfree((void *)dmc->cache_sets);
 	eio_ttc_put_device(&dmc->disk_dev);
 	eio_put_cache_device(dmc);
-	(void)wait_on_bit_lock((void *)&eio_control->synch_flags,
+	(void)wait_on_bit_lock_action((void *)&eio_control->synch_flags,
 			       EIO_UPDATE_LIST, eio_wait_schedule,
 			       TASK_UNINTERRUPTIBLE);
 	nodepp = &cache_list_head;
@@ -2387,7 +2392,7 @@ eio_notify_reboot(struct notifier_block *this, unsigned long code, void *x)
 	if (eio_reboot_notified == EIO_REBOOT_HANDLING_DONE)
 		return NOTIFY_DONE;
 
-	(void)wait_on_bit_lock((void *)&eio_control->synch_flags,
+	(void)wait_on_bit_lock_action((void *)&eio_control->synch_flags,
 			       EIO_HANDLE_REBOOT, eio_wait_schedule,
 			       TASK_UNINTERRUPTIBLE);
 	if (eio_reboot_notified == EIO_REBOOT_HANDLING_DONE) {
@@ -2400,7 +2405,7 @@ eio_notify_reboot(struct notifier_block *this, unsigned long code, void *x)
 	EIO_ASSERT(eio_reboot_notified == 0);
 	eio_reboot_notified = EIO_REBOOT_HANDLING_INPROG;
 
-	(void)wait_on_bit_lock((void *)&eio_control->synch_flags,
+	(void)wait_on_bit_lock_action((void *)&eio_control->synch_flags,
 			       EIO_UPDATE_LIST, eio_wait_schedule,
 			       TASK_UNINTERRUPTIBLE);
 	for (dmc = cache_list_head; dmc != NULL; dmc = dmc->next_cache) {

--- a/Driver/enhanceio/eio_procfs.c
+++ b/Driver/enhanceio/eio_procfs.c
@@ -52,7 +52,7 @@ static struct sysctl_table_dir *sysctl_handle_dir;
  * eio_zerostats_sysctl
  */
 static int
-eio_zerostats_sysctl(ctl_table *table, int write, void __user *buffer,
+eio_zerostats_sysctl(struct ctl_table *table, int write, void __user *buffer,
 		     size_t *length, loff_t *ppos)
 {
 	struct cache_c *dmc = (struct cache_c *)table->extra1;
@@ -120,7 +120,7 @@ eio_zerostats_sysctl(ctl_table *table, int write, void __user *buffer,
  * - sets the eio sysctl mem_limit_pct value
  */
 static int
-eio_mem_limit_pct_sysctl(ctl_table *table, int write, void __user *buffer,
+eio_mem_limit_pct_sysctl(struct ctl_table *table, int write, void __user *buffer,
 			 size_t *length, loff_t *ppos)
 {
 	struct cache_c *dmc = (struct cache_c *)table->extra1;
@@ -167,7 +167,7 @@ eio_mem_limit_pct_sysctl(ctl_table *table, int write, void __user *buffer,
  * eio_clean_sysctl
  */
 static int
-eio_clean_sysctl(ctl_table *table, int write, void __user *buffer,
+eio_clean_sysctl(struct ctl_table *table, int write, void __user *buffer,
 		 size_t *length, loff_t *ppos)
 {
 	struct cache_c *dmc = (struct cache_c *)table->extra1;
@@ -249,7 +249,7 @@ eio_clean_sysctl(ctl_table *table, int write, void __user *buffer,
  * eio_dirty_high_threshold_sysctl
  */
 static int
-eio_dirty_high_threshold_sysctl(ctl_table *table, int write,
+eio_dirty_high_threshold_sysctl(struct ctl_table *table, int write,
 				void __user *buffer, size_t *length,
 				loff_t *ppos)
 {
@@ -331,7 +331,7 @@ eio_dirty_high_threshold_sysctl(ctl_table *table, int write,
  * eio_dirty_low_threshold_sysctl
  */
 static int
-eio_dirty_low_threshold_sysctl(ctl_table *table, int write,
+eio_dirty_low_threshold_sysctl(struct ctl_table *table, int write,
 			       void __user *buffer, size_t *length,
 			       loff_t *ppos)
 {
@@ -419,7 +419,7 @@ eio_dirty_low_threshold_sysctl(ctl_table *table, int write,
  * eio_dirty_set_high_threshold_sysctl
  */
 static int
-eio_dirty_set_high_threshold_sysctl(ctl_table *table, int write,
+eio_dirty_set_high_threshold_sysctl(struct ctl_table *table, int write,
 				    void __user *buffer, size_t *length,
 				    loff_t *ppos)
 {
@@ -505,7 +505,7 @@ eio_dirty_set_high_threshold_sysctl(ctl_table *table, int write,
  * eio_dirty_set_low_threshold_sysctl
  */
 static int
-eio_dirty_set_low_threshold_sysctl(ctl_table *table, int write,
+eio_dirty_set_low_threshold_sysctl(struct ctl_table *table, int write,
 				   void __user *buffer, size_t *length,
 				   loff_t *ppos)
 {
@@ -598,7 +598,7 @@ eio_dirty_set_low_threshold_sysctl(ctl_table *table, int write,
  * eio_autoclean_threshold_sysctl
  */
 static int
-eio_autoclean_threshold_sysctl(ctl_table *table, int write,
+eio_autoclean_threshold_sysctl(struct ctl_table *table, int write,
 			       void __user *buffer, size_t *length,
 			       loff_t *ppos)
 {
@@ -674,7 +674,7 @@ eio_autoclean_threshold_sysctl(ctl_table *table, int write,
  * eio_time_based_clean_interval_sysctl
  */
 static int
-eio_time_based_clean_interval_sysctl(ctl_table *table, int write,
+eio_time_based_clean_interval_sysctl(struct ctl_table *table, int write,
 				     void __user *buffer, size_t *length,
 				     loff_t *ppos)
 {
@@ -768,7 +768,7 @@ static void eio_sysctl_unregister_invalidate(struct cache_c *dmc);
  * eio_control_sysctl
  */
 int
-eio_control_sysctl(ctl_table *table, int write, void __user *buffer,
+eio_control_sysctl(struct ctl_table *table, int write, void __user *buffer,
 		   size_t *length, loff_t *ppos)
 {
 	int rv = 0;
@@ -929,10 +929,10 @@ eio_control_sysctl(ctl_table *table, int write, void __user *buffer,
 #define PROC_IOSZ_HIST          "io_hist"
 #define PROC_CONFIG             "config"
 
-static int eio_invalidate_sysctl(ctl_table *table, int write,
+static int eio_invalidate_sysctl(struct ctl_table *table, int write,
 				 void __user *buffer, size_t *length,
 				 loff_t *ppos);
-static void *eio_find_sysctl_data(struct cache_c *dmc, ctl_table *vars);
+static void *eio_find_sysctl_data(struct cache_c *dmc, struct ctl_table *vars);
 static char *eio_cons_sysctl_devname(struct cache_c *dmc);
 static char *eio_cons_procfs_cachename(struct cache_c *dmc,
 				       char *path_component);
@@ -1011,10 +1011,10 @@ static const struct file_operations eio_config_operations = {
  */
 static struct sysctl_table_dir {
 	struct ctl_table_header *sysctl_header;
-	ctl_table vars[0 + 1];
-	ctl_table dev[0 + 1];
-	ctl_table dir[1 + 1];
-	ctl_table root[1 + 1];
+	struct ctl_table vars[0 + 1];
+	struct ctl_table dev[0 + 1];
+	struct ctl_table dir[1 + 1];
+	struct ctl_table root[1 + 1];
 } sysctl_template_dir = {
 	.vars = {
 	}, .dev	= {
@@ -1039,10 +1039,10 @@ static struct sysctl_table_dir {
 
 static struct sysctl_table_common {
 	struct ctl_table_header *sysctl_header;
-	ctl_table vars[NUM_COMMON_SYSCTLS + 1];
-	ctl_table dev[1 + 1];
-	ctl_table dir[1 + 1];
-	ctl_table root[1 + 1];
+	struct ctl_table vars[NUM_COMMON_SYSCTLS + 1];
+	struct ctl_table dev[1 + 1];
+	struct ctl_table dir[1 + 1];
+	struct ctl_table root[1 + 1];
 } sysctl_template_common = {
 	.vars = {
 		{               /* 1 */
@@ -1089,10 +1089,10 @@ static struct sysctl_table_common {
 
 static struct sysctl_table_writeback {
 	struct ctl_table_header *sysctl_header;
-	ctl_table vars[NUM_WRITEBACK_SYSCTLS + 1];
-	ctl_table dev[1 + 1];
-	ctl_table dir[1 + 1];
-	ctl_table root[1 + 1];
+	struct ctl_table vars[NUM_WRITEBACK_SYSCTLS + 1];
+	struct ctl_table dev[1 + 1];
+	struct ctl_table dir[1 + 1];
+	struct ctl_table root[1 + 1];
 } sysctl_template_writeback = {
 	.vars = {
 		{               /* 1 */
@@ -1169,10 +1169,10 @@ static struct sysctl_table_writeback {
 #define NUM_INVALIDATE_SYSCTLS          (1)
 static struct sysctl_table_invalidate {
 	struct ctl_table_header *sysctl_header;
-	ctl_table vars[NUM_INVALIDATE_SYSCTLS + 1];
-	ctl_table dev[1 + 1];
-	ctl_table dir[1 + 1];
-	ctl_table root[1 + 1];
+	struct ctl_table vars[NUM_INVALIDATE_SYSCTLS + 1];
+	struct ctl_table dev[1 + 1];
+	struct ctl_table dir[1 + 1];
+	struct ctl_table root[1 + 1];
 } sysctl_template_invalidate = {
 	.vars = {
 		{	/* 1 */
@@ -1317,7 +1317,7 @@ static spinlock_t invalidate_spin_lock;
  * eio_invalidate_sysctl
  */
 static int
-eio_invalidate_sysctl(ctl_table *table, int write, void __user *buffer,
+eio_invalidate_sysctl(struct ctl_table *table, int write, void __user *buffer,
 		      size_t *length, loff_t *ppos)
 {
 	static int have_sector;
@@ -1389,7 +1389,7 @@ eio_invalidate_sysctl(ctl_table *table, int write, void __user *buffer,
 /*
  * eio_find_sysctl_data
  */
-static void *eio_find_sysctl_data(struct cache_c *dmc, ctl_table *vars)
+static void *eio_find_sysctl_data(struct cache_c *dmc, struct ctl_table *vars)
 {
 
 	if (strcmp(vars->procname, "do_clean") == 0)

--- a/Driver/enhanceio/eio_ttc.c
+++ b/Driver/enhanceio/eio_ttc.c
@@ -31,6 +31,11 @@
 #include <linux/miscdevice.h>
 #include "eio.h"
 #include "eio_ttc.h"
+
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,17,0))
+#define wait_on_bit_lock_action wait_on_bit_lock
+#endif
+
 static struct rw_semaphore eio_ttc_lock[EIO_HASHTBL_SIZE];
 static struct list_head eio_ttc_list[EIO_HASHTBL_SIZE];
 
@@ -1497,7 +1502,7 @@ int eio_reboot_handling(void)
 	if (eio_reboot_notified == EIO_REBOOT_HANDLING_DONE)
 		return 0;
 
-	(void)wait_on_bit_lock((void *)&eio_control->synch_flags,
+	(void)wait_on_bit_lock_action((void *)&eio_control->synch_flags,
 			       EIO_HANDLE_REBOOT, eio_wait_schedule,
 			       TASK_UNINTERRUPTIBLE);
 	if (eio_reboot_notified == EIO_REBOOT_HANDLING_DONE) {

--- a/Driver/enhanceio/eio_ttc.c
+++ b/Driver/enhanceio/eio_ttc.c
@@ -36,6 +36,11 @@
 #define wait_on_bit_lock_action wait_on_bit_lock
 #endif
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,15,0))
+#define smp_mb__after_atomic smp_mb__after_clear_bit
+#endif
+
+
 static struct rw_semaphore eio_ttc_lock[EIO_HASHTBL_SIZE];
 static struct list_head eio_ttc_list[EIO_HASHTBL_SIZE];
 
@@ -1507,7 +1512,7 @@ int eio_reboot_handling(void)
 			       TASK_UNINTERRUPTIBLE);
 	if (eio_reboot_notified == EIO_REBOOT_HANDLING_DONE) {
 		clear_bit(EIO_HANDLE_REBOOT, (void *)&eio_control->synch_flags);
-		smp_mb__after_clear_bit();
+		smp_mb__after_atomic();
 		wake_up_bit((void *)&eio_control->synch_flags,
 			    EIO_HANDLE_REBOOT);
 		return 0;
@@ -1609,7 +1614,7 @@ int eio_reboot_handling(void)
 
 	eio_reboot_notified = EIO_REBOOT_HANDLING_DONE;
 	clear_bit(EIO_HANDLE_REBOOT, (void *)&eio_control->synch_flags);
-	smp_mb__after_clear_bit();
+	smp_mb__after_atomic();
 	wake_up_bit((void *)&eio_control->synch_flags, EIO_HANDLE_REBOOT);
 	return 0;
 }


### PR DESCRIPTION
These changes make EnhanceIO compile on 3.17 as well as on older kernels. It should fix #81.