### PR TITLE
Fix Makefile to correctly identify RHEL 5.X.

### DIFF
--- a/Driver/enhanceio/Makefile
+++ b/Driver/enhanceio/Makefile
@@ -8,7 +8,7 @@ KERNEL_TREE ?= /lib/modules/$(KERNEL_SOURCE_VERSION)/build
 EXTRA_CFLAGS += -I$(KERNEL_TREE)/drivers/md -I./ -DCOMMIT_REV="\"$(COMMIT_REV)\""
 EXTRA_CFLAGS += -I$(KERNEL_TREE)/include/ -I$(KERNEL_TREE)/include/linux 
 # Check for RHEL/CentOS
-RHEL5_VER ?= $(shell  if [ -e /etc/redhat-release ]; then grep 5.[0-9] /etc/redhat-release; else false; fi)
+RHEL5_VER ?= $(shell  if [ -e /etc/redhat-release ]; then grep " 5\.[0-9]" /etc/redhat-release; else false; fi)
 RHEL5_SETUP :=
 ifneq "$(RHEL5_VER)" ""
 	RHEL5_SETUP := rhel5-setup


### PR DESCRIPTION
Was incorrectly identifying CentOS Linux release 7.1.1503 as RHEL5 and would fail to compile.