### PR TITLE
Update eio_ttc.c

### DIFF
--- a/Driver/enhanceio/eio_ttc.c
+++ b/Driver/enhanceio/eio_ttc.c
@@ -1089,30 +1089,6 @@ int eio_cache_edit(char *cache_name, u_int32_t mode, u_int32_t policy)
 		restart_async_task = 1;
 	}
 
-	/* Wait for nr_dirty to drop to zero */
-	if (dmc->mode == CACHE_MODE_WB && mode != CACHE_MODE_WB) {
-		if (CACHE_FAILED_IS_SET(dmc)) {
-			pr_err
-				("cache_edit:  Can not proceed with edit for Failed cache \"%s\".",
-				dmc->cache_name);
-			error = -EINVAL;
-			goto out;
-		}
-
-		error = eio_finish_nrdirty(dmc);
-		/* This error can mostly occur due to Device removal */
-		if (unlikely(error)) {
-			pr_err
-				("cache_edit: nr_dirty FAILED to finish for cache \"%s\".",
-				dmc->cache_name);
-			goto out;
-		}
-		EIO_ASSERT((dmc->sysctl_active.do_clean & EIO_CLEAN_KEEP) &&
-			   !(dmc->sysctl_active.do_clean & EIO_CLEAN_START));
-		EIO_ASSERT(dmc->sysctl_active.fast_remove ||
-			   (atomic64_read(&dmc->nr_dirty) == 0));
-	}
-
 	index = EIO_HASH_BDEV(dmc->disk_dev->bdev->bd_contains->bd_dev);
 	down_write(&eio_ttc_lock[index]);
 


### PR DESCRIPTION
Lately, we found the substantial delay of cache mode change from writeback to others when write operations are heavy.

The delay is caused by flushing dirty ssd blocks to hard disk, but there is no need to flush.
 I think the dirty blocks on ssd does not affect to the writethrough and readonly mode. The cache consistency can be kept.