### PR TITLE
Fix a critical typo on eio_cli

### DIFF
--- a/CLI/eio_cli
+++ b/CLI/eio_cli
@@ -645,7 +645,7 @@ def main():
 			elif args.hdd:
 				cache = Cache_rec(name = args.cache,\
 						ssd_name = args.hdd, persistence = 1)
-				cache.do_eio_ioctl(EIO_IOC_HDD_ADD)
+				cache.do_eio_ioctl(EIO_IOC_SRC_ADD)
 
 		elif args.action == "remove":
 			if args.ssd:
@@ -655,7 +655,7 @@ def main():
 			elif args.hdd:
 				cache = Cache_rec(name = args.cache, hdd_name = args.hdd,\
 						persistence = 1)
-				cache.do_eio_ioctl(EIO_HDD_REMOVE)
+				cache.do_eio_ioctl(EIO_SRC_REMOVE)
 
 		pass
 


### PR DESCRIPTION
There is a typo on eio_cli (see the diff) causing serious issues when reassembling existing caches. Please review and merge this as soon as possible.