### PR TITLE
eio_cli: Allow udev rules to use device name only if no device uuid found

### DIFF
--- a/CLI/eio_cli
+++ b/CLI/eio_cli
@@ -198,6 +198,12 @@ def make_udev_match_expr(dev_path, cache_name):
 		match_expr= 'ENV{DM_NAME}!="' + cache_name + \
 		'", ENV{ID_FS_UUID}=="' + dict_udev["ID_FS_UUID"] + '"'
 		return match_expr
+		
+	# Fall through, use device names only
+	if dict_udev["DEVTYPE"] == "disk":
+		match_expr='KERNEL=="'+ dev_path.split('/')[-1] + \
+		'", ENV{DEVTYPE}=="'+ dict_udev["DEVTYPE"] +'"'
+		return match_expr
 
 
 def run_cmd(cmd):


### PR DESCRIPTION
If a device is lacking a UUID assigned by udev, use the kernel name if necessary rather than failing to generate udev rule.
