### PR TITLE
Update eio_procfs.c

### DIFF
--- a/Driver/enhanceio/eio_conf.c
+++ b/Driver/enhanceio/eio_conf.c
@@ -101,8 +101,10 @@ int eio_wait_schedule(void *unused)
 	return 0;
 }
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,15,0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,16,0))
+#ifndef smp_mb__after_atomic
 #define smp_mb__after_atomic smp_mb__after_clear_bit
+#endif
 #endif
 
 /*

--- a/Driver/enhanceio/eio_procfs.c
+++ b/Driver/enhanceio/eio_procfs.c
@@ -87,11 +87,12 @@ eio_zerostats_sysctl(struct ctl_table *table, int write, void __user *buffer,
 				("0 or 1 are the only valid values for zerostats");
 			return -EINVAL;
 		}
-
-		if (dmc->sysctl_pending.zerostats ==
-		    dmc->sysctl_active.zerostats)
-			/* same value. Nothing to work */
-			return 0;
+		
+		if (!dmc->sysctl_pending.zerostats)
+			if (dmc->sysctl_pending.zerostats ==
+		    	dmc->sysctl_active.zerostats)
+				/* same value. Nothing to work */
+				return 0;
 
 		/* Copy to active */
 		spin_lock_irqsave(&dmc->cache_spin_lock, flags);

--- a/Driver/enhanceio/eio_procfs.c
+++ b/Driver/enhanceio/eio_procfs.c
@@ -1056,7 +1056,7 @@ static struct sysctl_table_common {
 		{               /* 1 */
 			.procname	= "zero_stats",
 			.maxlen		= sizeof(int),
-			.mode		= 0644,
+			.mode		= 0200,
 			.proc_handler	= &eio_zerostats_sysctl,
 		}, {            /* 2 */
 			.procname	= "mem_limit_pct",

--- a/Driver/enhanceio/eio_ttc.c
+++ b/Driver/enhanceio/eio_ttc.c
@@ -36,8 +36,10 @@
 #define wait_on_bit_lock_action wait_on_bit_lock
 #endif
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,15,0))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,16,0))
+#ifndef smp_mb__after_atomic
 #define smp_mb__after_atomic smp_mb__after_clear_bit
+#endif
 #endif
 
 


### PR DESCRIPTION
Bugfix. Now every time you write "1" to "/proc/sys/dev/eio/<Cache_Name>/zero_stats", that stats will become zero.
